### PR TITLE
Allow working with custom synchronizers

### DIFF
--- a/build/jsdoc/api/conf.json
+++ b/build/jsdoc/api/conf.json
@@ -10,7 +10,8 @@
         "includePattern": ".+\\.js(doc)?$",
         "excludePattern": "(^|\\/|\\\\)_",
         "include": [
-            "src"
+            "src",
+            "externs"
         ]
     },
     "plugins": [

--- a/build/jsdoc/api/plugins/typedefs.js
+++ b/build/jsdoc/api/plugins/typedefs.js
@@ -1,10 +1,10 @@
 /*
- * Converts olx.js @type annotations into properties of the previous @typedef.
+ * Converts olcsx.js @type annotations into properties of the previous @typedef.
  * Changes @enum annotations into @typedef.
  */
 
-var lastOlxTypedef = null;
-var olxTypes = {};
+var lastOlcsxTypedef = null;
+var olcsxTypes = {};
 
 function addSubparams(params) {
   for (var j = 0, jj = params.length; j < jj; ++j) {
@@ -12,8 +12,8 @@ function addSubparams(params) {
     var types = param.type.names;
     for (var k = 0, kk = types.length; k < kk; ++k) {
       var name = types[k];
-      if (name in olxTypes) {
-        param.subparams = olxTypes[name];
+      if (name in olcsxTypes) {
+        param.subparams = olcsxTypes[name];
         // TODO addSubparams(param.subparams);
         // TODO Do we need to support multiple object literal types per
         // param?
@@ -27,20 +27,20 @@ exports.handlers = {
 
   newDoclet: function(e) {
     var doclet = e.doclet;
-    if (doclet.meta.filename == 'olx.js') {
+    if (doclet.meta.filename == 'olcsx.js') {
       // do nothing if not marked @api
       if (!doclet.stability) {
         return;
       }
       if (doclet.kind == 'typedef') {
-        lastOlxTypedef = doclet;
-        olxTypes[doclet.longname] = [];
+        lastOlcsxTypedef = doclet;
+        olcsxTypes[doclet.longname] = [];
         doclet.properties = [];
-      } else if (lastOlxTypedef && doclet.memberof == lastOlxTypedef.longname) {
-        lastOlxTypedef.properties.push(doclet);
-        olxTypes[lastOlxTypedef.longname].push(doclet);
+      } else if (lastOlcsxTypedef && doclet.memberof == lastOlcsxTypedef.longname) {
+        lastOlcsxTypedef.properties.push(doclet);
+        olcsxTypes[lastOlcsxTypedef.longname].push(doclet);
       } else {
-        lastOlxTypedef = null;
+        lastOlcsxTypedef = null;
       }
     } else if (doclet.isEnum) {
       // We never export enums, so we document them like typedefs

--- a/externs/olcsx.js
+++ b/externs/olcsx.js
@@ -5,6 +5,45 @@
  */
 var olcsx;
 
+
+/**
+ * @typedef {{
+ *   map: (!ol.Map),
+ *   target: (Element|string|undefined),
+ *   createSynchronizers: ((function(!ol.Map, !Cesium.Scene): Array.<olcs.AbstractSynchronizer>)|undefined)
+ * }}
+ * @api
+ */
+olcsx.OLCesiumOptions;
+
+
+/**
+ * The OpenLayers map we want to show on a Cesium scene.
+ * @type {!ol.Map}
+ * @api
+ */
+olcsx.OLCesiumOptions.prototype.map;
+
+
+/**
+ * Target element for the Cesium scene.
+ * @type {Element|string|undefined}
+ * @api
+ */
+olcsx.OLCesiumOptions.prototype.target;
+
+
+/**
+ * Callback function which will be called by the {@link olcs.OLCesium}
+ * constructor to create custom synchronizers. Receives an `ol.Map` and a
+ * `Cesium.Scene` as arguments, and needs to return an array of
+ * {@link olcs.AbstractSynchronizer}.
+ * @type {undefined|function(!ol.Map, !Cesium.Scene): Array.<olcs.AbstractSynchronizer>}
+ * @api
+ */
+olcsx.OLCesiumOptions.prototype.createSynchronizers;
+
+
 /**
  * Core namespace.
  * @type {Object}


### PR DESCRIPTION
This change allows developers to configure a `createSymbolizers` function for OLCesium, instead of relying on the default set of synchronizers.