### PR TITLE
Stop using deprecated setTransform

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -345,7 +345,7 @@ Cesium.Camera.prototype.worldToCameraCoordinatesPoint = function(cartesian, opt_
 
 
 /**
- * @param {!Cesium.Matrix4} transform
+ * @param {!Cesium.RemovedAPI} transform
  */
 Cesium.Camera.prototype.setTransform = function(transform) {};
 

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -522,6 +522,12 @@ Cesium.Camera.prototype.lookAt = function(eye, target, up) {};
 
 
 /**
+ * @param {Cesium.Matrix4} transform
+ */
+Cesium.Camera.prototype.lookAtTransform = function(transform) {};
+
+
+/**
  * @param {number} amount .
  */
 Cesium.Camera.prototype.twistLeft = function(amount) {};

--- a/src/core.js
+++ b/src/core.js
@@ -72,9 +72,9 @@ goog.require('olcs.core.OlLayerPrimitive');
       camera.transform.clone(oldTransform);
       var stepAngle = (progress - lastProgress) * angle;
       lastProgress = progress;
-      camera.setTransform(transform);
+      camera.lookAtTransform(transform);
       camera.rotate(axis, stepAngle);
-      camera.setTransform(oldTransform);
+      camera.lookAtTransform(oldTransform);
 
       if (progress < 1) {
         animation.start();


### PR DESCRIPTION
Deprecated `setTransform` will be removed in next release of Cesium.