### PR TITLE
Remove unused width attribute in polygon outline

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -793,12 +793,10 @@ goog.require('olcs.core.OlLayerPrimitive');
       perPositionHeight: true
     });
 
-    var width = extractLineWidthFromOlStyle(olStyle);
     var outlineGeometry = new Cesium.PolygonOutlineGeometry({
       // always update Cesium externs before adding a property
       polygonHierarchy: hierarchy,
-      perPositionHeight: true,
-      width: width
+      perPositionHeight: true
     });
 
     var primitives = wrapFillAndOutlineGeometries(


### PR DESCRIPTION
This attribute does not exist in Cesium.