### PR TITLE
Remove useless goog.require

### DIFF
--- a/src/core/olimageryprovider.js
+++ b/src/core/olimageryprovider.js
@@ -2,7 +2,6 @@ goog.provide('olcs.core.OLImageryProvider');
 
 goog.require('goog.events');
 goog.require('ol.proj');
-goog.require('ol.tilegrid');
 
 
 


### PR DESCRIPTION
This PR allows custom build when removing the "ignoreRequires" option.