### PR TITLE
Fix removal of billboard in the absence of a geometry

### DIFF
--- a/src/vectorsynchronizer.js
+++ b/src/vectorsynchronizer.js
@@ -96,14 +96,12 @@ olcs.VectorSynchronizer.prototype.createSingleCounterpart = function(olLayer) {
   var onRemoveFeature = goog.bind(function(feature) {
     var geometry = feature.getGeometry();
     var id = goog.getUid(feature);
-    if (goog.isDefAndNotNull(geometry) && geometry.getType() == 'Point') {
+    if (!geometry || geometry.getType() == 'Point') {
       var context = csPrimitives.context;
-      var bbs = context.billboards;
       var bb = context.featureToCesiumMap[id];
       delete context.featureToCesiumMap[id];
-      if (goog.isDefAndNotNull(bb)) {
-        goog.asserts.assertInstanceof(bb, Cesium.Billboard);
-        bbs.remove(bb);
+      if (bb instanceof Cesium.Billboard) {
+        context.billboards.remove(bb);
       }
     }
     var csPrimitive = featurePrimitiveMap[id];


### PR DESCRIPTION
When doing feature.setGeometry(null) on a Point feature, the Cesium
counterpart (Billboard) was not removed properly.

This PR handles this case.
The case when there is no geometry and no associated billboard is found
for this feature id is also handled.