### PR TITLE
Simple plugin mechanism

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
     overriden. As usual, subclassing requires that the subclass and the
     library code be compiled together by Closure. This change notably allows
     application code to handle projections not supported by Cesium.
+  * Allow application developers to easily compile plugin code together with
+    the library by putting their files in the src/plugins directory. See
+    src/plugins/README.md for details and instructions.
 
 ## v1.7 - 2015-08-07
 

--- a/src/plugins/.gitignore
+++ b/src/plugins/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except these files
+!README.md
+!.gitignore

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -1,0 +1,5 @@
+Extending the OL3-Cesium library classes requires both the library code and
+the extension code to be compiled together using the Closure compiler.
+
+You may want to put your extension code in this directory so that it is
+automatically compiled together with the library.


### PR DESCRIPTION
Allow compiling application code with the OL3-Cesium library by simply
putting plugin javascript code in the src/plugins directory.

User automatically gets error checking, styling and documentation.

This extension mechanism is intended for people not familiar with
Closure. More advanced use-cases should be handled with a custom build.