### PR TITLE
Follow symlinks in build/generate-info.js

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
     primitive collection may be retrieved with the `getRootPrimitive()` method.
 
 * Changes
+  * The `build/generate-info.js` tool now follows symlinks to properly
+    generate exports.
   * `olcs.RasterSynchronizer.prototype.convertLayerToCesiumImagery` may be
     overriden. As usual, subclassing requires that the subclass and the
     library code be compiled together by Closure. This change notably allows

--- a/build/generate-info.js
+++ b/build/generate-info.js
@@ -43,7 +43,7 @@ function getNewer(date, callback) {
   var paths = [];
   var newer = false;
 
-  var walker = walk(sourceDir);
+  var walker = walk(sourceDir, {followLinks: true});
   walker.on('file', function(root, stats, next) {
     var sourcePath = path.join(root, stats.name);
     if (/\.js$/.test(sourcePath)) {


### PR DESCRIPTION
Fixes symlink plugins exports missing from dist/exports.js.