### PR TITLE
Simple cesium resource control

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
     primitive collection may be retrieved with the `getRootPrimitive()` method.
 
 * Changes
+  * Allow blocking Cesium rendering to save resources using
+    `olcs.OLCesium#setBlockCesiumRendering(true)`.
   * The `build/generate-info.js` tool now follows symlinks to properly
     generate exports.
   * `olcs.RasterSynchronizer.prototype.convertLayerToCesiumImagery` may be

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -141,12 +141,19 @@ olcs.OLCesium = function(options) {
   this.camera_.readFromView();
 
   this.cesiumRenderingDelay_ = new goog.async.AnimationDelay(function(time) {
-    this.scene_.initializeFrame();
-    this.handleResize_();
-    this.scene_.render();
-    this.enabled_ && this.camera_.checkCameraChange();
+    if (!this.blockCesiumRendering_) {
+      this.scene_.initializeFrame();
+      this.handleResize_();
+      this.scene_.render();
+      this.enabled_ && this.camera_.checkCameraChange();
+    }
     this.cesiumRenderingDelay_.start();
   }, undefined, this);
+
+  /**
+   * @private
+   */
+  this.blockCesiumRendering_ = false;
 };
 
 
@@ -278,4 +285,14 @@ olcs.OLCesium.prototype.warmUp = function(height, timeout) {
   setTimeout(
       function() { !that.enabled_ && that.cesiumRenderingDelay_.stop(); },
       timeout);
+};
+
+
+/**
+ * Block Cesium rendering to save resources.
+ * @param {boolean} block True to block.
+ * @api
+*/
+olcs.OLCesium.prototype.setBlockCesiumRendering = function(block) {
+  this.blockCesiumRendering_ = block;
 };

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -255,10 +255,10 @@ olcs.OLCesium.prototype.setEnabled = function(enable) {
 
 
 /**
-* Preload Cesium so that it is ready when transitioning from 2D to 3D.
-* @param {number} height Target height of the camera
-* @param {number} timeout Milliseconds after which the warming will stop
-* @api
+ * Preload Cesium so that it is ready when transitioning from 2D to 3D.
+ * @param {number} height Target height of the camera
+ * @param {number} timeout Milliseconds after which the warming will stop
+ * @api
 */
 olcs.OLCesium.prototype.warmUp = function(height, timeout) {
   if (this.enabled_) {


### PR DESCRIPTION
This PR allows blocking Cesium rendering which is useful to save
resources. When no interaction is expected on the map, the application
can choose to block Cesium loop. Later on it may be unblocked.