### PR TITLE
GroundPrimitive

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -1057,6 +1057,21 @@ Cesium.Primitive.prototype.olFeature;
  */
 Cesium.Primitive.prototype.olLayer;
 
+
+/**
+ * @typedef {{
+ *   geometryInstance: !Cesium.GeometryInstance
+ * }}
+ */
+Cesium.optionsGroundPrimitive;
+
+/**
+ * @constructor
+ * @param {Cesium.optionsGroundPrimitive=} opt_opts
+ * @extends {Cesium.Primitive}
+ */
+Cesium.GroundPrimitive = function(opt_opts) {};
+
 /**
  * @constructor
  */

--- a/examples/vectors.html
+++ b/examples/vectors.html
@@ -21,6 +21,8 @@
       onclick="javascript:addOrRemoveOneVectorLayer()" /></div>
     <div><input type="button" value="Add/remove one feature"
       onclick="javascript:addOrRemoveOneFeature()" /></div>
+    <div><input type="button" value="Toggle clampToGround mode"
+      onclick="javascript:toggleClampToGround()" /></div>
     <div>Vectors are synchronized from the ol3 map to the Cesium scene.
       <br/>3D positioning and some styling is supported.</div>
     <script src="../ol3/build/ol.js"></script>

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -151,7 +151,6 @@ var dragAndDropInteraction = new ol.interaction.DragAndDrop({
 });
 
 
-
 var map = new ol.Map({
   interactions: ol.interaction.defaults().extend([dragAndDropInteraction]),
   layers: [
@@ -241,4 +240,17 @@ function toggleStyle() {
   var swap = theCircle.getStyle();
   theCircle.setStyle(oldStyle);
   oldStyle = swap;
+}
+
+function toggleClampToGround() {
+  var altitudeMode;
+  if (!vectorLayer.get('altitudeMode')) {
+    altitudeMode = 'clampToGround';
+  }
+  vectorLayer.set('altitudeMode', altitudeMode);
+  vectorLayer2.set('altitudeMode', altitudeMode);
+  map.removeLayer(vectorLayer);
+  map.removeLayer(vectorLayer2);
+  map.addLayer(vectorLayer);
+  map.addLayer(vectorLayer2);
 }


### PR DESCRIPTION
Use GroundPrimitive instead of Primitive when altittudeMode is set to clampToGround.

Ready for review @gberaudo .