### PR TITLE
Remove goog.array.forEach

### DIFF
--- a/src/abstractsynchronizer.js
+++ b/src/abstractsynchronizer.js
@@ -252,7 +252,7 @@ olcs.AbstractSynchronizer.prototype.listenForGroupChanges_ = function(group) {
   listenAddRemove();
 
   listenKeyArray.push(group.on('change:layers', function(e) {
-    goog.array.forEach(contentKeys, function(el) {
+    contentKeys.forEach(function(el) {
       goog.array.remove(listenKeyArray, el);
       ol.Observable.unByKey(el);
     });

--- a/src/core/olimageryprovider.js
+++ b/src/core/olimageryprovider.js
@@ -169,7 +169,7 @@ olcs.core.OLImageryProvider.createCreditForSource = function(source) {
   var text = '';
   var attributions = source.getAttributions();
   if (!goog.isNull(attributions)) {
-    goog.array.forEach(attributions, function(el, i, arr) {
+    attributions.forEach(function(el) {
       // strip html tags (not supported in Cesium)
       text += el.getHTML().replace(/<\/?[^>]+(>|$)/g, '') + ' ';
     });

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -1,6 +1,5 @@
 goog.provide('olcs.FeatureConverter');
 
-goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('ol.extent');
 goog.require('ol.geom.SimpleGeometry');
@@ -517,7 +516,7 @@ olcs.FeatureConverter.prototype.olMultiGeometryToCesium =
   // instead we create n primitives for simplicity.
   var accumulate = function(geometries, functor) {
     var primitives = new Cesium.PrimitiveCollection();
-    goog.array.forEach(geometries, function(geometry) {
+    geometries.forEach(function(geometry) {
       primitives.add(functor(layer, feature, geometry, projection, olStyle));
     });
     return primitives;
@@ -530,7 +529,7 @@ olcs.FeatureConverter.prototype.olMultiGeometryToCesium =
       subgeos = geometry.getPoints();
       if (olStyle.getText()) {
         var primitives = new Cesium.PrimitiveCollection();
-        goog.array.forEach(subgeos, function(geometry) {
+        subgeos.forEach(function(geometry) {
           goog.asserts.assert(geometry);
           var result = this.olPointGeometryToCesium(layer, feature, geometry,
               projection, olStyle, billboards, opt_newBillboardCallback);
@@ -540,7 +539,7 @@ olcs.FeatureConverter.prototype.olMultiGeometryToCesium =
         }.bind(this));
         return primitives;
       } else {
-        goog.array.forEach(subgeos, function(geometry) {
+        subgeos.forEach(function(geometry) {
           goog.asserts.assert(!goog.isNull(geometry));
           this.olPointGeometryToCesium(layer, feature, geometry, projection,
               olStyle, billboards, opt_newBillboardCallback);
@@ -768,7 +767,8 @@ olcs.FeatureConverter.prototype.olFeatureToCesium =
     case 'GeometryCollection':
       var primitives = new Cesium.PrimitiveCollection();
       var collection = /** @type {!ol.geom.GeometryCollection} */ (geom);
-      goog.array.forEach(collection.getGeometries(), function(geom) {
+      // TODO: use getGeometriesArray() instead
+      collection.getGeometries().forEach(function(geom) {
         if (geom) {
           var prims = this.olFeatureToCesium(layer, feature, style, context,
               geom);

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -244,9 +244,7 @@ olcs.OLCesium.prototype.setEnabled = function(enable) {
   } else {
     if (this.isOverMap_) {
       var interactions = this.map_.getInteractions();
-      goog.array.forEach(this.pausedInteractions_, function(el, i, arr) {
-        interactions.push(el);
-      }, this);
+      this.pausedInteractions_.forEach(interactions.push);
       this.pausedInteractions_.length = 0;
 
       if (!goog.isNull(this.hiddenRootGroup_)) {


### PR DESCRIPTION
Prefer standard Ecmascript 5.1 array.forEach instead of the function
provided by the closure library. This is part of a work to shrink dependency
on goog library.