### PR TITLE
Calculate Canvas size on initialisation

### DIFF
--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -126,6 +126,9 @@ olcs.OLCesium = function(options) {
         new olcs.VectorSynchronizer(this.map_, this.scene_)
       ];
 
+  // Assures correct canvas size after initialisation
+  this.handleResize_();
+
   for (var i = synchronizers.length - 1; i >= 0; --i) {
     synchronizers[i].synchronize();
   }
@@ -137,8 +140,6 @@ olcs.OLCesium = function(options) {
       credits.style.display = 'none';
     }
   }
-
-  this.camera_.readFromView();
 
   this.cesiumRenderingDelay_ = new goog.async.AnimationDelay(function(time) {
     if (!this.blockCesiumRendering_) {


### PR DESCRIPTION
When initialising ol3-cesium in 2D mode, the size of the canvas used is not correct. This will result in the wrong distance being calculated for the cesium camera.

The distance is calculated in the [`readView`](https://github.com/openlayers/ol3-cesium/blob/b06886cdb0958a75ff209782ac1af05bfebd6beb/src/camera.js#L378) function of the olcs.camera which is using the canvas dimensions.