### PR TITLE
Auto stop render loop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
     `olcs.RasterSynchronizer.prototype.convertLayerToCesiumImageries`.
 
 * Changes
+  * Add the experimental method `olcs.OLCesium.enableAutoRenderLoop` to stop
+    rendering the globe when idle. This is based on work from Kevin Ring.
   * Port to Cesium 1.14.
   * The `olcs.AbstractSynchronizer` now tries to synchronize the layer groups.
     Only if null is returned will it synchronize each of its children. This

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2346,9 +2346,19 @@ Cesium.Scene.prototype.initializeFrame = function() {};
 
 
 /**
- * @param {number|undefined} time The simulation time.
+ * @param {number=} opt_date
  */
-Cesium.Scene.prototype.render = function(time) {};
+Cesium.Scene.prototype.render = function(opt_date) {};
+
+/**
+ * @type {Cesium.Event}
+ */
+Cesium.Scene.prototype.preRender;
+
+/**
+ * @type {Cesium.Event}
+ */
+Cesium.Scene.prototype.postRender;
 
 
 /**

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2140,6 +2140,14 @@ Cesium.Matrix4 = function(opt_a00, opt_a10, opt_a20, opt_a30,
 
 
 /**
+ * @param {Cesium.Matrix4} matrix
+ * @param {Cesium.Matrix4=} opt_result
+ * @return {!Cesium.Matrix4}
+ */
+Cesium.Matrix4.clone = function(matrix, opt_result) {};
+
+
+/**
  * @param {Cesium.Cartesian3} translation .
  * @param {Cesium.Matrix4=} opt_result .
  * @return {!Cesium.Matrix4} .

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -3034,3 +3034,16 @@ Cesium.loadWithXhr;
  * @type {function(...)}
  */
 Cesium.loadWithXhr.load;
+
+
+/**
+ * @param {string} workerName
+ * @param {number=} opt_maximumActiveTasks
+ * @constructor
+ */
+Cesium.TaskProcessor = function(workerName, opt_maximumActiveTasks) {};
+
+/**
+ * @return {boolean}
+ */
+Cesium.TaskProcessor.prototype.isDestroyed = function() {};

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2187,6 +2187,14 @@ Cesium.Matrix4.prototype.equals = function(matrix) {};
 
 
 /**
+ * @param {Cesium.Matrix4} matrix
+ * @param {number} epsilon
+ * @return {boolean}
+ */
+Cesium.Matrix4.prototype.equalsEpsilon = function(matrix, epsilon) {};
+
+
+/**
  * @param {Cesium.Matrix4=} opt_result
  */
 Cesium.Matrix4.prototype.clone = function(opt_result) {};

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -3006,3 +3006,14 @@ Cesium.WebMapTileServiceImageryProviderOptions.prototype.layer;
  * @type {string}
  */
 Cesium.WebMapTileServiceImageryProviderOptions.prototype.url;
+
+
+/**
+ * @type {function(Object=)}
+ */
+Cesium.loadWithXhr;
+
+/**
+ * @type {function(...)}
+ */
+Cesium.loadWithXhr.load;

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -1531,6 +1531,12 @@ Cesium.DefaultProxy = function(proxy) {};
  */
 Cesium.Event = function() {};
 
+/**
+ * @param {function(...)} listener
+ * @param {Object=} opt_scope
+ * @return {function()}
+ */
+Cesium.Event.prototype.addEventListener = function(listener, opt_scope) {};
 
 
 /**

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2171,6 +2171,15 @@ Cesium.Matrix4.multiply = function(left, right, result) {};
 
 
 /**
+ * @param {Cesium.Matrix4|undefined} matrix1
+ * @param {Cesium.Matrix4|undefined} matrix2
+ * @param {number} epsilon
+ * @return {boolean}
+ */
+Cesium.Matrix4.equalsEpsilon = function(matrix1, matrix2, epsilon) {};
+
+
+/**
  * @param {Cesium.Matrix4} matrix .
  * @return {boolean} .
  */

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -275,3 +275,5 @@ function toggleClampToGround() {
   map.addLayer(vectorLayer);
   map.addLayer(vectorLayer2);
 }
+
+ol3d.enableAutoRenderLoop();

--- a/src/autorenderloop.js
+++ b/src/autorenderloop.js
@@ -1,0 +1,213 @@
+// Apache v2 license
+// https://github.com/TerriaJS/terriajs/blob/
+// ebd382a8278a817fce316730d9e459bbb9b829e9/lib/Models/Cesium.js
+
+goog.provide('olcs.AutoRenderLoop');
+
+
+
+/**
+ * @constructor
+ * @param {olcs.OLCesium} ol3d
+ * @param {boolean} debug
+ */
+olcs.AutoRenderLoop = function(ol3d, debug) {
+  this.ol3d = ol3d;
+  this.scene_ = ol3d.getCesiumScene();
+  this.verboseRendering = debug;
+  this._boundNotifyRepaintRequired = this.notifyRepaintRequired.bind(this);
+
+  this.lastCameraViewMatrix_ = new Cesium.Matrix4();
+  this.lastCameraMoveTime_ = 0;
+  this.stoppedRendering = false;
+
+  this._removePostRenderListener = this.scene_.postRender.addEventListener(
+      this.postRender.bind(this));
+
+
+  // Detect available wheel event
+  this._wheelEvent = '';
+  if ('onwheel' in this.scene_.canvas) {
+    // spec event type
+    this._wheelEvent = 'wheel';
+  } else if (!!document['onmousewheel']) {
+    // legacy event type
+    this._wheelEvent = 'mousewheel';
+  } else {
+    // older Firefox
+    this._wheelEvent = 'DOMMouseScroll';
+  }
+
+  this._originalLoadWithXhr = Cesium.loadWithXhr.load;
+  this._originalScheduleTask = Cesium.TaskProcessor.prototype.scheduleTask;
+
+  this.enable();
+};
+
+
+/**
+ * Force a repaint when the mouse moves or the window changes size.
+ * @param {string} key
+ * @param {boolean} capture
+ * @private
+ */
+olcs.AutoRenderLoop.prototype.repaintOn_ = function(key, capture) {
+  var canvas = this.scene_.canvas;
+  canvas.addEventListener(key, this._boundNotifyRepaintRequired, capture);
+};
+
+
+/**
+ * @param {string} key
+ * @param {boolean} capture
+ * @private
+ */
+olcs.AutoRenderLoop.prototype.removeRepaintOn_ = function(key, capture) {
+  var canvas = this.scene_.canvas;
+  canvas.removeEventListener(key, this._boundNotifyRepaintRequired, capture);
+};
+
+
+/**
+ * Enable.
+ */
+olcs.AutoRenderLoop.prototype.enable = function() {
+  this.repaintOn_('mousemove', false);
+  this.repaintOn_('mousedown', false);
+  this.repaintOn_('mouseup', false);
+  this.repaintOn_('touchstart', false);
+  this.repaintOn_('touchend', false);
+  this.repaintOn_('touchmove', false);
+
+  if (!!window['PointerEvent']) {
+    this.repaintOn_('pointerdown', false);
+    this.repaintOn_('pointerup', false);
+    this.repaintOn_('pointermove', false);
+  }
+
+  this.repaintOn_(this._wheelEvent, false);
+
+  window.addEventListener('resize', this._boundNotifyRepaintRequired, false);
+
+  // Hacky way to force a repaint when an async load request completes
+  var that = this;
+  Cesium.loadWithXhr.load = function(url, responseType, method, data,
+      headers, deferred, overrideMimeType, preferText, timeout) {
+    deferred['promise']['always'](that._boundNotifyRepaintRequired);
+    that._originalLoadWithXhr(url, responseType, method, data, headers,
+        deferred, overrideMimeType, preferText, timeout);
+  };
+
+  // Hacky way to force a repaint when a web worker sends something back.
+  Cesium.TaskProcessor.prototype.scheduleTask =
+      function(parameters, transferableObjects) {
+    var result = that._originalScheduleTask.call(this, parameters,
+        transferableObjects);
+
+    var taskProcessor = this;
+    if (!taskProcessor._originalWorkerMessageSinkRepaint) {
+      var worker = taskProcessor['_worker'];
+      taskProcessor._originalWorkerMessageSinkRepaint = worker.onmessage;
+      worker.onmessage = function(event) {
+        taskProcessor._originalWorkerMessageSinkRepaint(event);
+        that.notifyRepaintRequired();
+      };
+    }
+
+    return result;
+  };
+};
+
+
+/**
+ * Disable.
+ */
+olcs.AutoRenderLoop.prototype.disable = function() {
+  if (!!this._removePostRenderListener) {
+    this._removePostRenderListener();
+    this._removePostRenderListener = undefined;
+  }
+
+  this.removeRepaintOn_('mousemove', false);
+  this.removeRepaintOn_('mousedown', false);
+  this.removeRepaintOn_('mouseup', false);
+  this.removeRepaintOn_('touchstart', false);
+  this.removeRepaintOn_('touchend', false);
+  this.removeRepaintOn_('touchmove', false);
+
+  if (!!window['PointerEvent']) {
+    this.removeRepaintOn_('pointerdown', false);
+    this.removeRepaintOn_('pointerup', false);
+    this.removeRepaintOn_('pointermove', false);
+  }
+
+  this.removeRepaintOn_(this._wheelEvent, false);
+
+  window.removeEventListener('resize', this._boundNotifyRepaintRequired, false);
+
+  Cesium.loadWithXhr.load = this._originalLoadWithXhr;
+  Cesium.TaskProcessor.prototype.scheduleTask = this._originalScheduleTask;
+};
+
+
+/**
+ * @param {number} date
+ */
+olcs.AutoRenderLoop.prototype.postRender = function(date) {
+  // We can safely stop rendering when:
+  //  - the camera position hasn't changed in over a second,
+  //  - there are no tiles waiting to load, and
+  //  - the clock is not animating
+  //  - there are no tweens in progress
+
+  var now = Date.now();
+
+  var scene = this.scene_;
+  var camera = scene.camera;
+
+  if (!Cesium.Matrix4.equalsEpsilon(this.lastCameraViewMatrix_,
+      camera.viewMatrix, 1e-5)) {
+    this.lastCameraMoveTime_ = now;
+  }
+
+  var cameraMovedInLastSecond = now - this.lastCameraMoveTime_ < 1000;
+
+  var surface = scene.globe['_surface'];
+  var tilesWaiting = !surface['_tileProvider'].ready ||
+      surface['_tileLoadQueue'].length > 0 ||
+      surface['_debug']['tilesWaitingForChildren'] > 0;
+
+  var tweens = scene['tweens'];
+  if (!cameraMovedInLastSecond && !tilesWaiting && tweens.length == 0) {
+    if (this.verboseRendering) {
+      console.log('stopping rendering @ ' + Date.now());
+    }
+    this.ol3d.setBlockCesiumRendering(true);
+    this.stoppedRendering = true;
+  }
+
+  Cesium.Matrix4.clone(camera.viewMatrix, this.lastCameraViewMatrix_);
+};
+
+
+/**
+ * Notifies the viewer that a repaint is required.
+ */
+olcs.AutoRenderLoop.prototype.notifyRepaintRequired = function() {
+  if (this.verboseRendering && this.stoppedRendering) {
+    console.log('starting rendering @ ' + Date.now());
+  }
+  this._lastCameraMoveTime = Date.now();
+  // TODO: do not unblock if not blocked by us
+  this.ol3d.setBlockCesiumRendering(false);
+  this.stoppedRendering = false;
+};
+
+
+/**
+ * @param {boolean} debug
+ * @api
+ */
+olcs.AutoRenderLoop.prototype.setDebug = function(debug) {
+  this.verboseRendering = debug;
+};

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -2,6 +2,7 @@ goog.provide('olcs.OLCesium');
 
 goog.require('goog.async.AnimationDelay');
 goog.require('goog.dom');
+goog.require('olcs.AutoRenderLoop');
 goog.require('olcs.Camera');
 goog.require('olcs.RasterSynchronizer');
 goog.require('olcs.VectorSynchronizer');
@@ -14,6 +15,12 @@ goog.require('olcs.VectorSynchronizer');
  * @api
  */
 olcs.OLCesium = function(options) {
+
+  /**
+   * @type {olcs.AutoRenderLoop}
+   * @private
+   */
+  this.autoRenderLoop_ = null;
 
   /**
    * @type {!ol.Map}
@@ -312,4 +319,16 @@ olcs.OLCesium.prototype.warmUp = function(height, timeout) {
 */
 olcs.OLCesium.prototype.setBlockCesiumRendering = function(block) {
   this.blockCesiumRendering_ = block;
+};
+
+
+/**
+ * Render the globe only when necessary in order to save resources.
+ * Experimental.
+ * @api
+ */
+olcs.OLCesium.prototype.enableAutoRenderLoop = function() {
+  if (!this.autoRenderLoop_) {
+    this.autoRenderLoop_ = new olcs.AutoRenderLoop(this, false);
+  }
 };


### PR DESCRIPTION
This PR is an adaptation of [some code from Kevin Ring (NICTA)](https://github.com/TerriaJS/terriajs/blob/ebd382a8278a817fce316730d9e459bbb9b829e9/lib/Models/Cesium.js).
It allows automatically rendering the Cesium globe only when necessary, saving a lot of resource and battery on mobile devices.

The source project uses the Apache v2 license so I kept the code in a single file: `src/autorenderloop.js
` and added a comment at the top of the file. Is it OK to handle Apache2 code this way?
@kring, does it look fine for you?

This is `experimental` and `opt-in`: see the vector example for an example of use.
In the long run, it would be nice to have this directly in Cesium; there is a reflexion about it here:
https://github.com/AnalyticalGraphicsInc/cesium/issues/1865.