### PR TITLE
Add possibility to add datasources to 3D view

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2332,8 +2332,9 @@ Cesium.Scene.prototype.initializeFrame = function() {};
 
 
 /**
+ * @param {number|undefined} time The simulation time.
  */
-Cesium.Scene.prototype.render = function() {};
+Cesium.Scene.prototype.render = function(time) {};
 
 
 /**
@@ -2404,6 +2405,65 @@ Cesium.Scene.prototype.skyAtmosphere;
  * @type {number}
  */
 Cesium.Scene.prototype.maximumAliasedLineWidth;
+
+
+/**
+ * @constructor
+ */
+Cesium.JulianDate = function() {};
+
+
+/**
+ * @constructor
+ */
+Cesium.DataSource = function() {};
+
+
+/**
+ * @constructor
+ */
+Cesium.DataSourceCollection = function() {};
+
+/**
+ * @param {Cesium.DataSource|Promise.<Cesium.DataSource>} dataSource A data source or a promise to a data source to add to the collection.
+ *                                        When passing a promise, the data source will not actually be added
+ *                                        to the collection until the promise resolves successfully.
+ * @returns {Promise.<Cesium.DataSource>} A Promise that resolves once the data source has been added to the collection.
+ */
+Cesium.DataSourceCollection.prototype.add = function(dataSource) {};
+
+/**
+ * Removes a data source from this collection, if present.
+ *
+ * @param {Cesium.DataSource} dataSource The data source to remove.
+ * @param {Boolean} [destroy=false] Whether to destroy the data source in addition to removing it.
+ * @returns {Boolean} true if the data source was in the collection and was removed,
+ *                    false if the data source was not in the collection.
+ */
+Cesium.DataSourceCollection.prototype.remove = function(dataSource, destroy) {};
+
+
+/**
+ * @constructor
+ * @param {{scene: Cesium.Scene,
+            dataSourceCollection: Cesium.DataSourceCollection}} opt_opts
+ */
+Cesium.DataSourceDisplay = function(opt_opts) {};
+
+
+/**
+* @param {Cesium.JulianDate} time The simulation time.
+ * @returns {Boolean} True if all data sources are ready to be displayed, false otherwise.
+ */
+Cesium.DataSourceDisplay.prototype.update = function(time) {};
+
+
+/**
+ * @type {!Cesium.UniformState}
+ */
+Cesium.Context.prototype.uniformState;
+
+
 
 /**
  * @typedef {{

--- a/examples/kml.html
+++ b/examples/kml.html
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE HTML>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="robots" content="index, all" />
+    <title>ol3cesium kml example</title>
+    <link rel="stylesheet" href="../ol3/css/ol.css" type="text/css">
+  </head>
+  <body>
+    <div id="map" style="width:600px;height:400px;"></div>
+    <input type="button" value="Enable/disable" onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" />
+    <script src="../ol3/build/ol.js"></script>
+    <script src="../cesium/Build/Cesium/Cesium.js"></script>
+    <script src="/@loader"></script>
+    <script src="kml.js"></script>
+  </body>
+</html>

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -1,0 +1,30 @@
+var ol2d = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    })
+  ],
+  controls: ol.control.defaults({
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    })
+  }),
+  target: 'map',
+  view: new ol.View({
+    center: ol.proj.transform([25, 20], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 3
+  })
+});
+
+var ol3d = new olcs.OLCesium({map: ol2d});
+var scene = ol3d.getCesiumScene();
+var terrainProvider = new Cesium.CesiumTerrainProvider({
+    url : '//assets.agi.com/stk-terrain/world'
+});
+scene.terrainProvider = terrainProvider;
+
+ol3d.getDataSources().add(Cesium.KmlDataSource.load(
+  'https://api3.geo.admin.ch/ogcproxy?url=' +
+  'https%3A%2F%2Fdav0.bgdi.admin.ch%2Fbazl_web%2FActive_Obstacles.kmz'
+));
+

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -119,6 +119,12 @@ olcs.OLCesium = function(options) {
   this.scene_.globe = this.globe_;
   this.scene_.skyAtmosphere = new Cesium.SkyAtmosphere();
 
+  this.dataSourceCollection_ = new Cesium.DataSourceCollection();
+  this.dataSourceDisplay_ = new Cesium.DataSourceDisplay({
+    scene: this.scene_,
+    dataSourceCollection: this.dataSourceCollection_
+  });
+
   var synchronizers = goog.isDef(options.createSynchronizers) ?
       options.createSynchronizers(this.map_, this.scene_) :
       [
@@ -144,7 +150,8 @@ olcs.OLCesium = function(options) {
     if (!this.blockCesiumRendering_) {
       this.scene_.initializeFrame();
       this.handleResize_();
-      this.scene_.render();
+      this.dataSourceDisplay_.update(time);
+      this.scene_.render(time);
       this.enabled_ && this.camera_.checkCameraChange();
     }
     this.cesiumRenderingDelay_.start();
@@ -198,6 +205,15 @@ olcs.OLCesium.prototype.getOlMap = function() {
  */
 olcs.OLCesium.prototype.getCesiumScene = function() {
   return this.scene_;
+};
+
+
+/**
+ * @return {!Cesium.DataSourceCollection}
+ * @api
+ */
+olcs.OLCesium.prototype.getDataSources = function() {
+  return this.dataSourceCollection_;
 };
 
 


### PR DESCRIPTION
This PR adds the possibility to add datasources (KML, GEOJson) to the Cesium rendered view.

The handling of the datasources themselves are the responsibility of the clients of ol3-cesium.