### PR TITLE
Fix typo 'ineartia' to 'inertia'.

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2543,7 +2543,7 @@ Cesium.ScreenSpaceCameraController.prototype.inertiaSpin;
 /**
  * @type {number}
  */
-Cesium.ScreenSpaceCameraController.prototype.ineartiaTranslate;
+Cesium.ScreenSpaceCameraController.prototype.inertiaTranslate;
 
 /**
  * @type {number}

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -88,7 +88,7 @@ olcs.OLCesium = function(options) {
 
   var sscc = this.scene_.screenSpaceCameraController;
   sscc.inertiaSpin = 0;
-  sscc.ineartiaTranslate = 0;
+  sscc.inertiaTranslate = 0;
   sscc.inertiaZoom = 0;
 
   sscc.tiltEventTypes.push({


### PR DESCRIPTION
Trivial patch from @poppycocker.
Closes #262