### PR TITLE
Remove the group from layerMap list when it is removed

### DIFF
--- a/src/abstractsynchronizer.js
+++ b/src/abstractsynchronizer.js
@@ -195,6 +195,7 @@ olcs.AbstractSynchronizer.prototype.unlistenSingleGroup_ =
     ol.Observable.unByKey(key);
   });
   delete this.olGroupListenKeys_[uid];
+  delete this.layerMap[uid];
 };
 
 


### PR DESCRIPTION
Without removing the layerGroup from the `layerMap` list, we can't re-add it.