### PR TITLE
Keep the good order if no zIndex defined

### DIFF
--- a/src/abstractsynchronizer.js
+++ b/src/abstractsynchronizer.js
@@ -89,6 +89,10 @@ olcs.AbstractSynchronizer.prototype.synchronize = function() {
  */
 olcs.AbstractSynchronizer.flattenLayers =
     function(layer, foundLayers, foundGroups, opt_zIndices) {
+  foundLayers.push(layer);
+  if (opt_zIndices) {
+    opt_zIndices[goog.getUid(layer)] = layer.getZIndex();
+  }
   if (layer instanceof ol.layer.Group) {
     foundGroups.push(layer);
     var sublayers = layer.getLayers();
@@ -97,11 +101,6 @@ olcs.AbstractSynchronizer.flattenLayers =
         olcs.AbstractSynchronizer.flattenLayers(el, foundLayers, foundGroups,
             opt_zIndices);
       });
-    }
-  } else {
-    foundLayers.push(layer);
-    if (opt_zIndices) {
-      opt_zIndices[goog.getUid(layer)] = layer.getZIndex();
     }
   }
 };


### PR DESCRIPTION
Fixes https://github.com/geoadmin/mf-geoadmin3/issues/2712

This PR adds the groups to the list of `flattenLayers`, this keep the good order if no z-index are defined or if z-index are defined on a layer group.

The content `layerMap` array [here](https://github.com/openlayers/ol3-cesium/blob/ce86ef6ac25195c638c5ef0c7ffcf4dd2d51d51f/src/rastersynchronizer.js#L160) will decide which layers must be added to the map. 