### PR TITLE
Port to Cesium master (gulp, deprecated/removed API)

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -315,7 +315,7 @@ Cesium.Camera.prototype.constrainedAxisAngle;
 
 
 /**
- * @type {Cesium.Cartographic} .
+ * @type {!Cesium.Cartographic} .
  */
 Cesium.Camera.prototype.positionCartographic;
 
@@ -523,11 +523,22 @@ Cesium.Camera.prototype.setPositionCartographic;
 
 /**
  * @typedef {{
- *  position: (Cesium.Cartesian3|undefined),
- *  positionCartographic: (Cesium.Cartographic|undefined),
- *  heading: (number|undefined),
- *  pitch: (number|undefined),
- *  roll: (number|undefined)
+ *    heading: (number|undefined),
+ *    pitch: (number|undefined),
+ *    roll: (number|undefined)
+ * }}
+ */
+Cesium.optionsOrientation;
+
+/**
+ * @typedef {{
+ *  destination: (Cesium.Cartesian3|Cesium.Rectangle|undefined),
+ *  orientation: (Cesium.optionsOrientation|undefined),
+ *  position: (Cesium.RemovedAPI|undefined),
+ *  positionCartographic: (Cesium.RemovedAPI|undefined),
+ *  heading: (undefined|Cesium.RemovedAPI),
+ *  pitch: (undefined|Cesium.RemovedAPI),
+ *  roll: (undefined|Cesium.RemovedAPI)
  * }}
  */
 Cesium.optionsCameraSetView;

--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,16 @@ ol3/build/ol-externs.js:
 ol3/build/olX:
 	(cd ol3 && npm install && make build)
 
+cesium/node_modules/.bin/gulp: cesium/package.json
+	cd cesium && npm install
+
 # Only generated when cesium/Build/Cesium/Cesium.js does not exist
-cesium/Build/Cesium/Cesium.js:
+# or CHANGES.md changed
 ifndef NO_CESIUM
-	(cd cesium && ./Tools/apache-ant-1.8.2/bin/ant $(CESIUM_COMPILE_TARGET))
+cesium/Build/Cesium/Cesium.js: cesium/CHANGES.md cesium/node_modules/.bin/gulp
+	print 'HELLO'
+	(cd cesium && node_modules/.bin/gulp $(CESIUM_COMPILE_TARGET))
 else
+cesium/Build/Cesium/Cesium.js:
 	mkdir -p cesium/Build/Cesium/
 endif

--- a/src/camera.js
+++ b/src/camera.js
@@ -347,10 +347,17 @@ olcs.Camera.prototype.updateCamera_ = function() {
     carto.height = goog.isDef(height) ? height : 0;
   }
 
-  this.cam_.setView({
-    positionCartographic: carto,
+  var destination = Cesium.Ellipsoid.WGS84.cartographicToCartesian(carto);
+
+  /** @type {Cesium.optionsOrientation} */
+  var orientation = {
     pitch: this.tilt_ - Cesium.Math.PI_OVER_TWO,
-    heading: -this.view_.getRotation()
+    heading: -this.view_.getRotation(),
+    roll: undefined
+  };
+  this.cam_.setView({
+    destination: destination,
+    orientation: orientation
   });
 
   this.cam_.moveBackward(this.distance_);


### PR DESCRIPTION
Cesium switched its build system from ant to gulp.
This version also renamed/deprecated some APIs.

Todo later: use RectangleGeometry instead of RectanglePrimitive for selection.
See #277.

Update: add link to 277 issue