### PR TITLE
Honour pixel ratio and allow degrading quality for performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
     `olcs.RasterSynchronizer.prototype.convertLayerToCesiumImageries`.
 
 * Changes
+  * Add `olcs.OLCesium.setResolutionScale` to allow improving performance at
+    the cost of quality.
+  * Automatically use device pixel ratio to configure the Webgl 3D globe.
   * Add the experimental method `olcs.OLCesium.enableAutoRenderLoop` to stop
     rendering the globe when idle. This is based on work from Kevin Ring.
   * Port to Cesium 1.14.

--- a/src/camera.js
+++ b/src/camera.js
@@ -497,7 +497,7 @@ olcs.Camera.prototype.calcDistanceForResolution_ = function(resolution,
   var metersPerUnit = this.view_.getProjection().getMetersPerUnit();
 
   // number of "map units" visible in 2D (vertically)
-  var visibleMapUnits = resolution * canvas.height;
+  var visibleMapUnits = resolution * canvas.clientHeight;
 
   // The metersPerUnit does not take latitude into account, but it should
   // be lower with increasing latitude -- we have to compensate.
@@ -540,7 +540,7 @@ olcs.Camera.prototype.calcResolutionForDistance_ = function(distance,
   var visibleMeters = 2 * distance * Math.tan(fovy / 2);
   var relativeCircumference = Math.cos(Math.abs(latitude));
   var visibleMapUnits = visibleMeters / metersPerUnit / relativeCircumference;
-  var resolution = visibleMapUnits / canvas.height;
+  var resolution = visibleMapUnits / canvas.clientHeight;
 
   return resolution;
 };

--- a/src/core.js
+++ b/src/core.js
@@ -21,7 +21,8 @@ olcs.core.computePixelSizeAtCoordinate = function(scene, target) {
   var camera = scene.camera;
   var canvas = scene.canvas;
   var frustum = camera.frustum;
-  var canvasDimensions = new Cesium.Cartesian2(canvas.width, canvas.height);
+  var canvasDimensions = new Cesium.Cartesian2(
+      canvas.clientWidth, canvas.clientHeight);
   var distance = Cesium.Cartesian3.magnitude(Cesium.Cartesian3.subtract(
       camera.position, target, new Cesium.Cartesian3()));
   var pixelSize = frustum.getPixelSize(canvasDimensions, distance);
@@ -170,7 +171,8 @@ olcs.core.pickOnTerrainOrEllipsoid = function(scene, pixel) {
  */
 olcs.core.pickBottomPoint = function(scene) {
   var canvas = scene.canvas;
-  var bottom = new Cesium.Cartesian2(canvas.width / 2, canvas.height);
+  var bottom = new Cesium.Cartesian2(
+      canvas.clientWidth / 2, canvas.clientHeight);
   return olcs.core.pickOnTerrainOrEllipsoid(scene, bottom);
 };
 
@@ -183,7 +185,9 @@ olcs.core.pickBottomPoint = function(scene) {
  */
 olcs.core.pickCenterPoint = function(scene) {
   var canvas = scene.canvas;
-  var center = new Cesium.Cartesian2(canvas.width / 2, canvas.height / 2);
+  var center = new Cesium.Cartesian2(
+      canvas.clientWidth / 2,
+      canvas.clientHeight / 2);
   return olcs.core.pickOnTerrainOrEllipsoid(scene, center);
 };
 


### PR DESCRIPTION
Add `olcs.OLCesium.setResolutionScale` to allow improving performance at the cost of quality.
Automatically use device pixel ratio to configure the Webgl 3D globe.