### PR TITLE
Test if the source of a ol.layer.Image is usable by the vector synchr…

### DIFF
--- a/src/vectorsynchronizer.js
+++ b/src/vectorsynchronizer.js
@@ -87,7 +87,8 @@ olcs.VectorSynchronizer.prototype.removeAllCesiumObjects = function(destroy) {
 olcs.VectorSynchronizer.prototype.createSingleLayerCounterparts =
     function(olLayer) {
   if (!(olLayer instanceof ol.layer.Vector) &&
-      !(olLayer instanceof ol.layer.Image)) {
+      !(olLayer instanceof ol.layer.Image &&
+      olLayer.getSource() instanceof ol.source.ImageVector)) {
     return null;
   }
   goog.asserts.assertInstanceof(olLayer, ol.layer.Layer);


### PR DESCRIPTION
…onizer.

This PR avoid an assert error when a `ol.layer.Image` use a non-`ol.source.ImageVector` like `ol.source.WMS` for example.