### PR TITLE
Compile OL3-Cesium together with OL3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.10
+
+* Breaking changes
+  * OL3-Cesium is now compiled together with OL3. A custom closure compiler
+    build is no more required.
+
 ## v1.9 - 2015-10-22
 
 * Breaking changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,11 @@ where `<target>` is the name of the target you want to execute. For example:
 
     $ make dist
 
+## Compliler version
+
+The version of the compiler may be changed by creating a file closure-util.json
+at the root of the project. See [available options](https://github.com/openlayers/closure-util/blob/master/default-config.json)
+and [available compilers](https://github.com/google/closure-compiler/wiki/Binary-Downloads).
 
 ## Pull request guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 npm-install: .build/node_modules.timestamp
 
 .PHONY: serve
-serve: npm-install ol3/build/olX cesium/Build/Cesium/Cesium.js
+serve: npm-install cesium/Build/Cesium/Cesium.js
 	node build/serve.js
 
 .PHONY: dist
@@ -86,7 +86,7 @@ cleanall: clean
 	.build/python-venv/bin/gjslint --jslint_error=all --strict --custom_jsdoc_tags=api $?
 	touch $@
 
-.build/dist-examples.timestamp: ol3/build/olX cesium/Build/Cesium/Cesium.js dist/ol3cesium.js $(EXAMPLES_JS_FILES) $(EXAMPLES_HTML_FILES)
+.build/dist-examples.timestamp: cesium/Build/Cesium/Cesium.js dist/ol3cesium.js $(EXAMPLES_JS_FILES) $(EXAMPLES_HTML_FILES)
 	node build/parse-examples.js
 	mkdir -p $(dir $@)
 	mkdir -p dist/ol3
@@ -126,10 +126,6 @@ dist/ol3cesium.js: build/ol3cesium.json $(SRC_JS_FILES) ol3/build/ol-externs.js 
 .PHONY: ol3/build/ol-externs.js
 ol3/build/ol-externs.js:
 	(cd ol3 && npm install && node tasks/generate-externs.js build/ol-externs.js)
-
-.PHONY: ol3/build/olX
-ol3/build/olX:
-	(cd ol3 && npm install && make build)
 
 cesium/node_modules/.bin/gulp: cesium/package.json
 	cd cesium && npm install

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ clean:
 	rm -f ol3/build/ol.js
 	rm -f ol3/build/ol-debug.js
 	rm -f ol3/build/ol.css
-	rm -f ol3/build/ol-externs.js
 	rm -rf cesium/Build/Cesium
 	rm -rf cesium/Build/CesiumUnminified
 	rm -rf dist/ol3
@@ -89,15 +88,9 @@ cleanall: clean
 .build/dist-examples.timestamp: cesium/Build/Cesium/Cesium.js dist/ol3cesium.js $(EXAMPLES_JS_FILES) $(EXAMPLES_HTML_FILES)
 	node build/parse-examples.js
 	mkdir -p $(dir $@)
-	mkdir -p dist/ol3
-	cp ol3/build/ol-debug.js dist/ol3/
-	cp ol3/build/ol.js dist/ol3/
-	mkdir -p dist/ol3/css
-	cp ol3/build/ol.css dist/ol3/css/
 	cp -R cesium/Build/Cesium dist/
 	cp -R examples dist/
 	for f in dist/examples/*.html; do $(SEDI) 'sY/@loaderY../ol3cesium.jsY' $$f; done
-	for f in dist/examples/*.html; do $(SEDI) 'sY../ol3/build/ol.jsY../ol3/ol-debug.jsY' $$f; done
 	for f in dist/examples/*.html; do $(SEDI) 'sY../cesium/Build/Y../Y' $$f; done
 	for f in dist/examples/*.js; do $(SEDI) 'sY../cesium/Build/Y../Y' $$f; done
 	touch $@
@@ -110,22 +103,26 @@ cleanall: clean
 	.build/python-venv/bin/pip install "http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
 	touch $@
 
-dist/ol3cesium-debug.js: build/ol3cesium-debug.json $(SRC_JS_FILES) ol3/build/ol-externs.js Cesium.externs.js build/build.js npm-install
+dist/ol3cesium-debug.js: build/ol3cesium-debug.json $(SRC_JS_FILES) Cesium.externs.js build/build.js npm-install
 	mkdir -p $(dir $@)
 	node build/build.js $< $@
 
+
+ol3/node_modules/rbush/package.json: ol3/package.json
+	(cd ol3 && npm install --production)
+
+ol3/build/ol.ext/rbush.js: ol3/node_modules/rbush/package.json
+	(cd ol3 && node tasks/build-ext.js)
+
+
 # A sourcemap is prepared, the source is exected to be deployed in 'source' directory
-dist/ol3cesium.js: build/ol3cesium.json $(SRC_JS_FILES) ol3/build/ol-externs.js Cesium.externs.js build/build.js npm-install
+dist/ol3cesium.js: build/ol3cesium.json $(SRC_JS_FILES) Cesium.externs.js build/build.js npm-install ol3/build/ol.ext/rbush.js
 	mkdir -p $(dir $@)
 	node build/build.js $< $@
 	$(SEDI) 's!$(shell pwd)/dist!source!g' dist/ol3cesium.js.map
 	$(SEDI) 's!$(shell pwd)!source!g' dist/ol3cesium.js.map
 #	echo '//# sourceMappingURL=ol3cesium.js.map' >> dist/ol3cesium.js
 #	-ln -s .. dist/source
-
-.PHONY: ol3/build/ol-externs.js
-ol3/build/ol-externs.js:
-	(cd ol3 && npm install && node tasks/generate-externs.js build/ol-externs.js)
 
 cesium/node_modules/.bin/gulp: cesium/package.json
 	cd cesium && npm install

--- a/build/build.js
+++ b/build/build.js
@@ -119,7 +119,6 @@ function getDependencies(config, exports, callback) {
         cwd: root
       };
     }
-    options.ignoreRequires = config.ignoreRequires;
     closure.getDependencies(options, function(err, paths) {
       if (err) {
         callback(err);

--- a/build/generate-info.js
+++ b/build/generate-info.js
@@ -6,7 +6,9 @@ var async = require('async');
 var fse = require('fs-extra');
 var walk = require('walk').walk;
 
-var sourceDir = path.join(__dirname, '..', 'src');
+var sourceDirOL = path.join(__dirname, '..', 'ol3', 'src');
+var sourceDirSelf = path.join(__dirname, '..', 'src');
+var sourceDirs = [sourceDirOL, sourceDirSelf];
 var infoPath = path.join(__dirname, '..', '.build', 'info.json');
 var jsdoc = path.join(__dirname, '..', 'node_modules', '.bin', 'jsdoc');
 var jsdocConfig = path.join(__dirname, 'jsdoc', 'info', 'conf.json');
@@ -40,25 +42,33 @@ function getInfoTime(callback) {
  *     error and the array of source paths (empty if none newer).
  */
 function getNewer(date, callback) {
-  var paths = [];
   var newer = false;
+  var paths = [];
 
-  var walker = walk(sourceDir, {followLinks: true});
-  walker.on('file', function(root, stats, next) {
-    var sourcePath = path.join(root, stats.name);
-    if (/\.js$/.test(sourcePath)) {
-      paths.push(sourcePath);
-      if (stats.mtime > date) {
-        newer = true;
-      }
-    }
-    next();
+  var tasks = sourceDirs.map(function(sourceDir) {
+    return function(callback) {
+      var walker = walk(sourceDir, {followLinks: true});
+      walker.on('file', function(root, stats, next) {
+        var sourcePath = path.join(root, stats.name);
+        if (/\.js$/.test(sourcePath)) {
+          paths.push(sourcePath);
+          if (stats.mtime > date) {
+            newer = true;
+          }
+        }
+        next();
+      });
+      walker.on('errors', function() {
+        callback(new Error('Trouble walking ' + sourceDir));
+      });
+      walker.on('end', function() {
+        callback(null);
+      });
+    };
   });
-  walker.on('errors', function() {
-    callback(new Error('Trouble walking ' + sourceDir));
-  });
-  walker.on('end', function() {
-    callback(null, newer ? paths : []);
+
+  async.series(tasks, function(err, results) {
+    callback(err, newer ? paths : []);
   });
 }
 

--- a/build/ol3cesium-debug.json
+++ b/build/ol3cesium-debug.json
@@ -1,4 +1,8 @@
 {
-  "ignoreRequires": "^ol\\.",
+  "src": [
+    "src/**/*.js",
+    "ol3/src/**/*.js",
+    "ol3/build/ol.ext/*.js"
+  ],
   "exports": ["*"]
 }

--- a/build/ol3cesium.json
+++ b/build/ol3cesium.json
@@ -40,6 +40,7 @@
     "language_in": "ECMASCRIPT5_STRICT",
     "language_out": "ECMASCRIPT5_STRICT",
     "warning_level": "VERBOSE",
+    "generate_exports": true,
     "output_wrapper": "(function(){%output%}).call(window);",
     "use_types_for_optimization": true,
     "create_source_map": "dist/ol3cesium.js.map",

--- a/build/ol3cesium.json
+++ b/build/ol3cesium.json
@@ -1,12 +1,22 @@
 {
   "exports": ["*"],
-  "src": ["src/**/*.js"],
-  "ignoreRequires": "^ol\\.",
+  "src": [
+    "src/**/*.js",
+    "ol3/src/**/*.js",
+    "ol3/build/ol.ext/*.js"
+  ],
   "compile": {
     "externs": [
-      "ol3/build/ol-externs.js",
-      "ol3/externs/esrijson.js",
       "externs/olcsx.js",
+      "ol3/externs/oli.js",
+      "ol3/externs/olx.js",
+      "ol3/externs/proj4js.js",
+      "ol3/externs/tilejson.js",
+      "ol3/externs/topojson.js",
+      "ol3/externs/esrijson.js",
+      "ol3/externs/geojson.js",
+      "ol3/externs/bingmaps.js",
+      "ol3/externs/closure-compiler.js",
       "Cesium.externs.js"
     ],
     "define": [

--- a/build/serve.js
+++ b/build/serve.js
@@ -30,9 +30,10 @@ log.info('ol3-cesium', 'Parsing dependencies ...');
 var manager = new closure.Manager({
   closure: true, // use the bundled Closure Library
   lib: [
-    'src/**/*.js'
-  ],
-  ignoreRequires: '^ol\\.'
+    'src/**/*.js',
+    'ol3/src/**/*.js',
+    'ol3/build/ol.ext/*.js'
+  ]
 });
 manager.on('error', function(e) {
   log.error('ol3-cesium', e.message);

--- a/closure-util.json
+++ b/closure-util.json
@@ -1,4 +1,4 @@
 {
-  "compiler_url": "http://dev.camptocamp.com/files/closure-compiler/compiler-20150903.zip",
-  "library_url": "https://github.com/google/closure-library/archive/b129bb.zip"
+  "Allowed keys, see":  "https://github.com/openlayers/closure-util/blob/master/default-config.json",
+  "See downloads at": "https://github.com/google/closure-compiler/wiki/Binary-Downloads"
 }

--- a/closure-util.json
+++ b/closure-util.json
@@ -1,4 +1,0 @@
-{
-  "Allowed keys, see":  "https://github.com/openlayers/closure-util/blob/master/default-config.json",
-  "See downloads at": "https://github.com/google/closure-compiler/wiki/Binary-Downloads"
-}

--- a/examples/dragbox.html
+++ b/examples/dragbox.html
@@ -12,7 +12,6 @@
     <div id="map3d" style="width:600px;height:400px;float:left;position:relative;"></div>
     <div>A zone may be selected in ol3 or Cesium map using maj+drag and trigger an event.
       <br/>Then application code may react to the event by zooming, selecting features, ...</div>
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="dragbox.js"></script>

--- a/examples/epsg-4326.html
+++ b/examples/epsg-4326.html
@@ -10,7 +10,6 @@
   <body>
     <div id="map2d" style="width:600px;height:400px;float:left;"></div>
     <input type="button" value="Enable/disable" onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" />
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="epsg-4326.js"></script>

--- a/examples/exports.html
+++ b/examples/exports.html
@@ -20,7 +20,6 @@
     <input type="button" value="lookAt([35, 40])" onclick="javascript:camera.lookAt(ol.proj.transform([35, 40], 'EPSG:4326', 'EPSG:3857'))" />
     <input type="button" value="setCenter([40, 45])" onclick="javascript:camera.setCenter(ol.proj.transform([40, 45], 'EPSG:4326', 'EPSG:3857'))" />
     <input type="button" value="setPosition([45, 50])" onclick="javascript:camera.setPosition(ol.proj.transform([45, 50], 'EPSG:4326', 'EPSG:3857'))" />
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="exports.js"></script>

--- a/examples/kml.html
+++ b/examples/kml.html
@@ -10,7 +10,6 @@
   <body>
     <div id="map" style="width:600px;height:400px;"></div>
     <input type="button" value="Enable/disable" onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" />
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="kml.js"></script>

--- a/examples/lazy.html
+++ b/examples/lazy.html
@@ -12,7 +12,6 @@
     <div>This is an experimental feature.</div>
     <div id="map" style="width:600px;height:400px;"></div>
     <input type="button" value="Enable/disable 3D" onclick="javascript:toggle3D()" />
-    <script src="../ol3/build/ol.js"></script>
     <script src="/@loader"></script>
     <script src="lazy.js"></script>
   </body>

--- a/examples/main.html
+++ b/examples/main.html
@@ -10,7 +10,6 @@
   <body>
     <div id="map" style="width:600px;height:400px;"></div>
     <input type="button" value="Enable/disable" onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" />
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="main.js"></script>

--- a/examples/rastersync.html
+++ b/examples/rastersync.html
@@ -53,7 +53,6 @@
       <label>Z-index</label>
       <input type="range" min="-10" max="10" step="1" oninput="layer2.setZIndex(this.value)" />
     </fieldset>
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="rastersync.js"></script>

--- a/examples/selection.html
+++ b/examples/selection.html
@@ -13,7 +13,6 @@
     <div>A country may be highlighted by clicking it on the ol3 map.
       <br/>It gets automatically selected in Cesium.
       <br/>If you see flickering in Cesium, please check your graphic card drivers.</div>
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="selection.js"></script>

--- a/examples/sidebyside.html
+++ b/examples/sidebyside.html
@@ -11,7 +11,6 @@
     <div id="map2d" style="width:600px;height:400px;float:left;"></div>
     <div id="map3d" style="width:600px;height:400px;float:left;position:relative;"></div>
     <input type="button" value="Enable/disable" onclick="javascript:ol3d.setEnabled(!ol3d.getEnabled())" />
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="sidebyside.js"></script>

--- a/examples/synthvectors.html
+++ b/examples/synthvectors.html
@@ -16,7 +16,6 @@
     <div id="created"></div>
     <div id="added"></div>
     <input type="button" value="Clear" onclick="javascript:clearFeatures()" />
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="synthvectors.js"></script>

--- a/examples/synthvectors_batch.html
+++ b/examples/synthvectors_batch.html
@@ -18,7 +18,6 @@
     <input type="button" value="Clear" onclick="javascript:clearFeatures()" />
     <div>Click to add a new layer of 1000 randomly colored circles.
       <br />Other shapes or icons may be used in spite of the circles.
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="synthvectors_batch.js"></script>

--- a/examples/vectors.html
+++ b/examples/vectors.html
@@ -25,7 +25,6 @@
       onclick="javascript:toggleClampToGround(); ol3d.getAutoRenderLoop().restartRenderLoop()" /></div>
     <div>Vectors are synchronized from the ol3 map to the Cesium scene.
       <br/>3D positioning and some styling is supported.<br />The render loop is automatically stopped when idle.</div>
-    <script src="../ol3/build/ol.js"></script>
     <script src="../cesium/Build/Cesium/Cesium.js"></script>
     <script src="/@loader"></script>
     <script src="vectors.js"></script>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "htmlparser2": "~3.7.1"
   },
   "devDependencies": {
-    "closure-util": "1.7.0",
+    "closure-util": "1.8.0",
     "geojsonhint": "^1.0.0",
     "fs-extra": "~0.8.1",
     "graceful-fs": "~3.0.2",

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -4,6 +4,7 @@ goog.require('goog.asserts');
 goog.require('ol.extent');
 goog.require('ol.geom.SimpleGeometry');
 goog.require('olcs.core.VectorLayerCounterpart');
+goog.require('olcs.obj');
 
 
 
@@ -42,7 +43,7 @@ olcs.FeatureConverter.prototype.onRemoveOrClearFeature_ = function(evt) {
   var source = evt.target;
   goog.asserts.assertInstanceof(source, ol.source.Vector);
 
-  var cancellers = source['olcs_cancellers'];
+  var cancellers = olcs.obj(source)['olcs_cancellers'];
   if (cancellers) {
     var feature = evt.feature;
     if (goog.isDef(feature)) {
@@ -60,7 +61,7 @@ olcs.FeatureConverter.prototype.onRemoveOrClearFeature_ = function(evt) {
           cancellers[key]();
         }
       }
-      source['olcs_cancellers'] = {};
+      olcs.obj(source)['olcs_cancellers'] = {};
     }
   }
 };
@@ -540,10 +541,13 @@ olcs.FeatureConverter.prototype.olPointGeometryToCesium =
       };
       source.on(['removefeature', 'clear'],
           this.boundOnRemoveOrClearFeatureListener_);
-      source['olcs_cancellers'] = source['olcs_cancellers'] || {};
+      var cancellers = olcs.obj(source)['olcs_cancellers'];
+      if (!cancellers) {
+        cancellers = olcs.obj(source)['olcs_cancellers'] = {};
+      }
 
-      goog.asserts.assert(!source['olcs_cancellers'][goog.getUid(feature)]);
-      source['olcs_cancellers'][goog.getUid(feature)] = canceller;
+      goog.asserts.assert(!cancellers[goog.getUid(feature)]);
+      cancellers[goog.getUid(feature)] = canceller;
 
       var listener = function() {
         if (!billboards.isDestroyed() && !cancelled) {

--- a/src/olcs.js
+++ b/src/olcs.js
@@ -1,0 +1,11 @@
+goog.provide('olcs.obj');
+
+
+/**
+ * Cast to object.
+ * @param {Object} param
+ * @return {Object}
+ */
+olcs.obj = function(param) {
+  return param;
+};


### PR DESCRIPTION
OL3-Cesium used to be compiled against OL3 externs.
This was unnatural for a Closure project and had shortcomings:
- a custom closure compiler was required;
- we were restricted to OL3 @api symbols;
- OL3 externs were sometimes buggy;
- the goog library was included twice;
...

This change bundles the OL3 code together with OL3-Cesium, which is already what we do in Ngeo.
This will allow adding client side raster reprojection in the future.