### PR TITLE
Honor devicePixelRatio like in Cesium

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   * OL3-Cesium is now compiled together with OL3. A custom closure compiler
     build is no more required.
 
+* Changes
+  * Automatically use device pixel ratio (the right way) to configure the
+    Webgl 3D globe. See https://github.com/AnalyticalGraphicsInc/cesium/pull/3233.
+
 ## v1.9 - 2015-10-22
 
 * Breaking changes

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -211,7 +211,7 @@ olcs.OLCesium.prototype.handleResize_ = function() {
     return;
   }
 
-  var zoomFactor = (window.devicePixelRatio || 1.0) * this.resolutionScale_;
+  var zoomFactor = this.resolutionScale_ / (window.devicePixelRatio || 1.0);
   this.resolutionScaleChanged_ = false;
 
   this.canvasClientWidth_ = width;


### PR DESCRIPTION
The Cesium team updated their default handling of pixel ratio.
On devices with pixelRatio > 1, the buffer used for rendering the scene will be smaller than the size of the canvas (clientWidth, clientHeight) and scaled afterwards.
This change drastically improves FPS on smartphones and reduces bandwidth usage.