### PR TITLE
Add entities to the globe

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2567,6 +2567,33 @@ Cesium.DataSourceDisplay.prototype.update = function(time) {};
 
 
 /**
+ * @type {Cesium.CustomDataSource}
+ */
+Cesium.DataSourceDisplay.prototype.defaultDataSource;
+
+
+
+/**
+ * @param {string} name
+ * @constructor
+ */
+Cesium.CustomDataSource = function(name) {};
+
+
+/**
+ * @type {Cesium.EntityCollection}
+ */
+Cesium.CustomDataSource.prototype.entities;
+
+
+
+/**
+ * @constructor
+ */
+Cesium.EntityCollection = function() {}
+
+
+/**
  * @type {!Cesium.UniformState}
  */
 Cesium.Context.prototype.uniformState;

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -263,6 +263,15 @@ olcs.OLCesium.prototype.getDataSources = function() {
 
 
 /**
+ * @return {!Cesium.DataSourceDisplay}
+ * @api
+ */
+olcs.OLCesium.prototype.getDataSourceDisplay = function() {
+  return this.dataSourceDisplay_;
+};
+
+
+/**
  * @return {boolean}
  * @api
  */


### PR DESCRIPTION
Allow adding Cesium entities to the globe.
See https://groups.google.com/forum/#!topic/ol3-dev/koro6VTogn0

```
var entity = {
    name: 'Green wall from surface with outline',
    wall: {
        positions: Cesium.Cartesian3.fromDegreesArrayHeights(
             [-107.0, 43.0, 100000.0, -107.0, 40.0, 100000.0, -107.0, 43.0, 100000.0]
        ),
        material: Cesium.Color.GREEN
    }
}
ol3d.getDataSourceDisplay().defaultDataSource.entities.add(entity);
```