### PR TITLE
Take into account scale on icons

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -140,6 +140,7 @@ Cesium.BillboardCollection = function(opt_options) {};
  *   verticalOrigin: (Cesium.VerticalOrigin|undefined),
  *   horizontalOrigin: (Cesium.HorizontalOrigin|undefined),
  *   pixelOffsetScaleByDistance : (Cesium.NearFarScalar|undefined),
+ *   scale: (number|undefined),
  *   scaleByDistance: (Cesium.NearFarScalar|undefined),
  *   position: !Cesium.Cartesian3
  * }}

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -518,6 +518,7 @@ olcs.FeatureConverter.prototype.olPointGeometryToCesium =
         // always update Cesium externs before adding a property
         image: image,
         color: color,
+        scale: imageStyle.getScale(),
         heightReference: heightReference,
         verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
         position: position


### PR DESCRIPTION
otherwise this might happen: 
![screen shot 2015-12-10 at 13 19 50](https://cloud.githubusercontent.com/assets/319678/11717370/6edccbbc-9f50-11e5-877b-b99598aed237.png)
