### PR TITLE
Fix layer group removal

### DIFF
--- a/src/abstractsynchronizer.js
+++ b/src/abstractsynchronizer.js
@@ -186,7 +186,9 @@ olcs.AbstractSynchronizer.prototype.removeLayer_ = function(root) {
       var done = this.removeAndDestroySingleLayer_(olLayer);
       if (olLayer instanceof ol.layer.Group) {
         this.unlistenSingleGroup_(olLayer);
-        if (done) {
+        if (!done) {
+          // No counterpart for the group itself so removing
+          // each of the child layers.
           olLayer.getLayers().forEach(function(l) {
             fifo.push(l);
           });


### PR DESCRIPTION
Layers in a layergroup were not properly removed.

Remove counterparts associated to individual layers when there is no
counterpart associated to the group itself.