### PR TITLE
Allow passing of Cesium.Scene initialization properties

### DIFF
--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -2374,14 +2374,22 @@ Cesium.Fog.prototype.density;
  */
 Cesium.Fog.prototype.screenSpaceErrorFactor;
 
+/**
+ * @typedef {{
+ *   canvas: (!HTMLCanvasElement),
+ *   contextOptions: (!Object|undefined),
+ *   creditContainer: (!Element|undefined),
+ *   mapProjection: (!Object|undefined),
+ *   orderIndependentTranslucency: (!boolean|undefined),
+ *   scene3DOnly: (!boolean|undefined),
+ *   terrainExaggeration: (!number|undefined)
+ *   }}
+ */
+Cesium.SceneOptions;
 
 /**
  * @constructor
- * @param {{canvas: HTMLCanvasElement,
-            contextOptions: (Object|undefined),
-            creditContainer: (Element|undefined),
-            mapProjection: (Object|undefined),
-            scene3DOnly: (boolean|undefined)}} opt_opts
+ * @param {!Cesium.SceneOptions} opt_opts
  */
 Cesium.Scene = function(opt_opts) {};
 
@@ -2409,6 +2417,10 @@ Cesium.Scene.prototype.context;
  */
 Cesium.Scene.prototype.fog;
 
+/**
+ * @type {!number}
+ */
+Cesium.Scene.prototype.terrainExaggeration;
 
 /**
  */

--- a/externs/olcsx.js
+++ b/externs/olcsx.js
@@ -10,7 +10,8 @@ var olcsx;
  * @typedef {{
  *   map: (!ol.Map),
  *   target: (Element|string|undefined),
- *   createSynchronizers: (undefined|function(!ol.Map, !Cesium.Scene): Array.<olcs.AbstractSynchronizer>)
+ *   createSynchronizers: (undefined|function(!ol.Map, !Cesium.Scene): Array.<olcs.AbstractSynchronizer>),
+ *   sceneOptions: (Cesium.SceneOptions|undefined)
  * }}
  * @api
  */
@@ -24,6 +25,12 @@ olcsx.OLCesiumOptions;
  */
 olcsx.OLCesiumOptions.prototype.map;
 
+/**
+ * Allows the passing of property value to the `Cesium.Scene`.
+ * @type {Cesium.SceneOptions|undefined}
+ * @api
+ */
+olcsx.OLCesiumOptions.prototype.sceneOptions;
 
 /**
  * Target element for the Cesium scene.

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -117,14 +117,16 @@ olcs.OLCesium = function(options) {
    */
   this.hiddenRootGroup_ = null;
 
+  var sceneOptions = options.sceneOptions !== undefined ? options.sceneOptions :
+      /** @type {Cesium.SceneOptions} */ ({});
+  sceneOptions.canvas = this.canvas_;
+  sceneOptions.scene3DOnly = true;
+
   /**
    * @type {!Cesium.Scene}
    * @private
    */
-  this.scene_ = new Cesium.Scene({
-    canvas: this.canvas_,
-    scene3DOnly: true
-  });
+  this.scene_ = new Cesium.Scene(sceneOptions);
 
   var sscc = this.scene_.screenSpaceCameraController;
   sscc.inertiaSpin = 0;


### PR DESCRIPTION
I added some code for passing `Cesium.Scene` initialization parameters to the `olcs.OLCesium` object. In my use case this allowed me to pass a *terrainExaggeration* value. `Cesium.Scene` offers a range of interesting settings, which is why I think it should be possible to pass parameters to it.