### PR TITLE
Add support for Cesium rectangles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 # Changelog
 
 * Changes
-  * Added support for Cesium rectangles via the olcs.polygon_kind property.
+  * Add support for drawing rectangles according to the longitude and latitude
+    curves instead of straight lines. This functionality can be activated by
+    setting the olcs.polygon_kind property to 'rectangle' on the OpenLayers
+    geometry.
 
 ## v 1.15 - 2016-04-28
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Changes
+  * Added support for Cesium rectangles via the olcs.polygon_kind property.
+
 ## v 1.15 - 2016-04-28
 
 * Changes

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -1483,6 +1483,14 @@ Cesium.PolygonOutlineGeometry = function(object) {};
 
 
 /**
+ * @constructor
+ * @param {Object=} object
+ * @extends {Cesium.Geometry}
+ */
+Cesium.RectangleOutlineGeometry = function(object) {};
+
+
+/**
  * @typedef {{
  * positions: !Array.<Cesium.Cartesian3>,
  * vertexFormat: number
@@ -1497,6 +1505,23 @@ Cesium.optionsPolylineGeometry;
  * @extends {Cesium.Geometry}
  */
 Cesium.PolylineGeometry = function(object) {};
+
+
+/**
+ * @typedef {{
+ * rectangle: {Cesium.Rectangle},
+ * vertexFormat: number
+ * }}
+ */
+Cesium.optionsRectangleGeometry;
+
+
+/**
+ * @constructor
+ * @param {Object=} object
+ * @extends {Cesium.Geometry}
+ */
+Cesium.RectangleGeometry = function(object) {};
 
 
 

--- a/Cesium.externs.js
+++ b/Cesium.externs.js
@@ -1483,11 +1483,24 @@ Cesium.PolygonOutlineGeometry = function(object) {};
 
 
 /**
+ * @typedef {{
+ * rectangle: !Cesium.Rectangle,
+ * ellipsoid: (Cesium.Ellipsoid|undefined),
+ * granularity: (number|undefined),
+ * height: (number|undefined),
+ * rotation: (number|undefined),
+ * extrudedHeight: (number|undefined)
+ * }}
+ */
+Cesium.optionsRectangleOutlineGeometry;
+
+
+/**
  * @constructor
- * @param {Object=} object
+ * @param {Cesium.optionsRectangleOutlineGeometry} opt_opts
  * @extends {Cesium.Geometry}
  */
-Cesium.RectangleOutlineGeometry = function(object) {};
+Cesium.RectangleOutlineGeometry = function(opt_opts) {};
 
 
 /**
@@ -1509,8 +1522,16 @@ Cesium.PolylineGeometry = function(object) {};
 
 /**
  * @typedef {{
- * rectangle: {Cesium.Rectangle},
- * vertexFormat: number
+ * rectangle: !Cesium.Rectangle,
+ * vertexFormat: (Cesium.VertexFormat|undefined),
+ * ellipsoid: (Cesium.Ellipsoid|undefined),
+ * granularity: (number|undefined),
+ * height: (number|undefined),
+ * rotation: (number|undefined),
+ * stRotation: (number|undefined),
+ * extrudedHeight: (number|undefined),
+ * closeTop: (boolean|undefined),
+ * closeBottom: (boolean|undefined)
  * }}
  */
 Cesium.optionsRectangleGeometry;
@@ -1518,10 +1539,10 @@ Cesium.optionsRectangleGeometry;
 
 /**
  * @constructor
- * @param {Object=} object
+ * @param {Cesium.optionsRectangleGeometry} opt_opts
  * @extends {Cesium.Geometry}
  */
-Cesium.RectangleGeometry = function(object) {};
+Cesium.RectangleGeometry = function(opt_opts) {};
 
 
 

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -21,32 +21,32 @@ var iconStyle = new ol.style.Style({
     src: 'data/icon.png'
   })),
   text: new ol.style.Text({
-     text: 'Some text',
-     textAlign: 'center',
-     textBaseline: 'middle',
-     stroke: new ol.style.Stroke({
-       color: 'magenta',
-       width: 3
-     }),
-     fill: new ol.style.Fill({
-       color: 'rgba(0, 0, 155, 0.3)'
-     })
-   })
+    text: 'Some text',
+    textAlign: 'center',
+    textBaseline: 'middle',
+    stroke: new ol.style.Stroke({
+      color: 'magenta',
+      width: 3
+    }),
+    fill: new ol.style.Fill({
+      color: 'rgba(0, 0, 155, 0.3)'
+    })
+  })
 });
 
 var textStyle = new ol.style.Style({
   text: new ol.style.Text({
-     text: 'Only text',
-     textAlign: 'center',
-     textBaseline: 'middle',
-     stroke: new ol.style.Stroke({
-       color: 'red',
-       width: 3
-     }),
-     fill: new ol.style.Fill({
-       color: 'rgba(0, 0, 155, 0.3)'
-     })
-   })
+    text: 'Only text',
+    textAlign: 'center',
+    textBaseline: 'middle',
+    stroke: new ol.style.Stroke({
+      color: 'red',
+      width: 3
+    }),
+    fill: new ol.style.Fill({
+      color: 'rgba(0, 0, 155, 0.3)'
+    })
+  })
 });
 
 iconFeature.setStyle(iconStyle);
@@ -147,13 +147,25 @@ var vectorSource = new ol.source.Vector({
 
 var theCircle = new ol.Feature(new ol.geom.Circle([5e6, 7e6, 5e5], 1e6));
 
+// Render a Cesium rectangle, via setting the property olcs.polygon_kind
+var cartographicRectangleStyle = new ol.style.Style({
+  fill: new ol.style.Fill({color: 'rgba(255, 69, 0, 0.7)'
+  })});
+var cartographicRectangleGeometry = new ol.geom.Polygon([[[-5e6, 11e6],
+        [4e6, 11e6], [4e6, 10e6], [-5e6, 10e6], [-5e6, 11e6]]]);
+cartographicRectangleGeometry.set('olcs.polygon_kind', 'rectangle');
+var cartographicRectangle = new ol.Feature({
+  geometry: cartographicRectangleGeometry
+});
+cartographicRectangle.setStyle(cartographicRectangleStyle);
+
 var vectorLayer = new ol.layer.Vector({
   source: vectorSource,
   style: styleFunction
 });
 
 var vectorSource2 = new ol.source.Vector({
-  features: [iconFeature, textFeature, cervinFeature]
+  features: [iconFeature, textFeature, cervinFeature, cartographicRectangle]
 });
 var imageVectorSource = new ol.source.ImageVector({
   source: vectorSource2

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -149,8 +149,14 @@ var theCircle = new ol.Feature(new ol.geom.Circle([5e6, 7e6, 5e5], 1e6));
 
 // Add a Cesium rectangle, via setting the property olcs.polygon_kind
 var cartographicRectangleStyle = new ol.style.Style({
-  fill: new ol.style.Fill({color: 'rgba(255, 69, 0, 0.7)'
-  })});
+  fill: new ol.style.Fill({
+    color: 'rgba(255, 69, 0, 0.7)'
+  }),
+  stroke: new ol.style.Stroke({
+    color: 'rgba(255, 69, 0, 0.9)',
+    width: 1
+  })
+});
 var cartographicRectangleGeometry = new ol.geom.Polygon([[[-5e6, 11e6],
         [4e6, 11e6], [4e6, 10.5e6], [-5e6, 10.5e6], [-5e6, 11e6]]]);
 cartographicRectangleGeometry.set('olcs.polygon_kind', 'rectangle');

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -147,17 +147,34 @@ var vectorSource = new ol.source.Vector({
 
 var theCircle = new ol.Feature(new ol.geom.Circle([5e6, 7e6, 5e5], 1e6));
 
-// Render a Cesium rectangle, via setting the property olcs.polygon_kind
+// Add a Cesium rectangle, via setting the property olcs.polygon_kind
 var cartographicRectangleStyle = new ol.style.Style({
   fill: new ol.style.Fill({color: 'rgba(255, 69, 0, 0.7)'
   })});
 var cartographicRectangleGeometry = new ol.geom.Polygon([[[-5e6, 11e6],
-        [4e6, 11e6], [4e6, 10e6], [-5e6, 10e6], [-5e6, 11e6]]]);
+        [4e6, 11e6], [4e6, 10.5e6], [-5e6, 10.5e6], [-5e6, 11e6]]]);
 cartographicRectangleGeometry.set('olcs.polygon_kind', 'rectangle');
 var cartographicRectangle = new ol.Feature({
   geometry: cartographicRectangleGeometry
 });
 cartographicRectangle.setStyle(cartographicRectangleStyle);
+
+// Add two Cesium rectangles with height and the property olcs.polygon_kind
+var cartographicRectangleGeometry2 = new ol.geom.MultiPolygon([
+  [[
+    [-5e6, 12e6, 0], [4e6, 12e6, 0], [4e6, 11.5e6, 0], [-5e6, 11.5e6, 0],
+    [-5e6, 12e6, 0]
+  ]],
+  [[
+    [-5e6, 11.5e6, 1e6], [4e6, 11.5e6, 1e6], [4e6, 11e6, 1e6],
+    [-5e6, 11e6, 1e6], [-5e6, 11.5e6, 1e6]
+  ]]
+]);
+cartographicRectangleGeometry2.set('olcs.polygon_kind', 'rectangle');
+var cartographicRectangle2 = new ol.Feature({
+  geometry: cartographicRectangleGeometry2
+});
+cartographicRectangle2.setStyle(cartographicRectangleStyle);
 
 var vectorLayer = new ol.layer.Vector({
   source: vectorSource,
@@ -165,7 +182,8 @@ var vectorLayer = new ol.layer.Vector({
 });
 
 var vectorSource2 = new ol.source.Vector({
-  features: [iconFeature, textFeature, cervinFeature, cartographicRectangle]
+  features: [iconFeature, textFeature, cervinFeature, cartographicRectangle,
+    cartographicRectangle2]
 });
 var imageVectorSource = new ol.source.ImageVector({
   source: vectorSource2

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -401,7 +401,8 @@ olcs.FeatureConverter.prototype.olPolygonGeometryToCesium =
   if (feature.getGeometry().get('olcs.polygon_kind') === 'rectangle') {
     // Extract the West, South, East, North coordinates
     var extent = ol.extent.boundingExtent(olGeometry.getCoordinates()[0]);
-    var rectangle = Cesium.Rectangle.fromDegrees(extent[0], extent[1], extent[2], extent[3]);
+    var rectangle = Cesium.Rectangle.fromDegrees(extent[0], extent[1],
+      extent[2], extent[3]);
 
     // Render the cartographic rectangle
     fillGeometry = new Cesium.RectangleGeometry({

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -402,7 +402,7 @@ olcs.FeatureConverter.prototype.olPolygonGeometryToCesium =
     // Extract the West, South, East, North coordinates
     var extent = ol.extent.boundingExtent(olGeometry.getCoordinates()[0]);
     var rectangle = Cesium.Rectangle.fromDegrees(extent[0], extent[1],
-      extent[2], extent[3]);
+        extent[2], extent[3]);
 
     // Render the cartographic rectangle
     fillGeometry = new Cesium.RectangleGeometry({

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -399,20 +399,32 @@ olcs.FeatureConverter.prototype.olPolygonGeometryToCesium =
 
   var fillGeometry, outlineGeometry;
   if (feature.getGeometry().get('olcs.polygon_kind') === 'rectangle') {
+    var coordinates = olGeometry.getCoordinates()[0];
     // Extract the West, South, East, North coordinates
-    var extent = ol.extent.boundingExtent(olGeometry.getCoordinates()[0]);
+    var extent = ol.extent.boundingExtent(coordinates);
     var rectangle = Cesium.Rectangle.fromDegrees(extent[0], extent[1],
         extent[2], extent[3]);
+
+    // Extract the average height of the vertices
+    var height = 0.0;
+    if (coordinates[0].length == 3) {
+      for (var c = 0; c < coordinates.length; c++) {
+        height += coordinates[c][2];
+      }
+      height /= coordinates.length;
+    }
 
     // Render the cartographic rectangle
     fillGeometry = new Cesium.RectangleGeometry({
       ellipsoid: Cesium.Ellipsoid.WGS84,
-      rectangle: rectangle
+      rectangle: rectangle,
+      height: height
     });
 
     outlineGeometry = new Cesium.RectangleOutlineGeometry({
       ellipsoid: Cesium.Ellipsoid.WGS84,
-      rectangle: rectangle
+      rectangle: rectangle,
+      height: height
     });
   } else {
     var rings = olGeometry.getLinearRings();

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -398,7 +398,9 @@ olcs.FeatureConverter.prototype.olPolygonGeometryToCesium =
   goog.asserts.assert(olGeometry.getType() == 'Polygon');
 
   var fillGeometry, outlineGeometry;
-  if (feature.getGeometry().get('olcs.polygon_kind') === 'rectangle') {
+  if ((olGeometry.getCoordinates()[0].length == 5) &&
+      (feature.getGeometry().get('olcs.polygon_kind') === 'rectangle')) {
+    // Create a rectangle according to the longitude and latitude curves
     var coordinates = olGeometry.getCoordinates()[0];
     // Extract the West, South, East, North coordinates
     var extent = ol.extent.boundingExtent(coordinates);
@@ -406,25 +408,24 @@ olcs.FeatureConverter.prototype.olPolygonGeometryToCesium =
         extent[2], extent[3]);
 
     // Extract the average height of the vertices
-    var height = 0.0;
+    var maxHeight = 0.0;
     if (coordinates[0].length == 3) {
       for (var c = 0; c < coordinates.length; c++) {
-        height += coordinates[c][2];
+        maxHeight = Math.max(maxHeight, coordinates[c][2]);
       }
-      height /= coordinates.length;
     }
 
     // Render the cartographic rectangle
     fillGeometry = new Cesium.RectangleGeometry({
       ellipsoid: Cesium.Ellipsoid.WGS84,
       rectangle: rectangle,
-      height: height
+      height: maxHeight
     });
 
     outlineGeometry = new Cesium.RectangleOutlineGeometry({
       ellipsoid: Cesium.Ellipsoid.WGS84,
       rectangle: rectangle,
-      height: height
+      height: maxHeight
     });
   } else {
     var rings = olGeometry.getLinearRings();


### PR DESCRIPTION
This PR is to support Cesium rectangles.
Closes: https://github.com/openlayers/ol3-cesium/issues/355.

We should document this functionality somewhere, as it is not straightforward.

`geometry.set('olcs.polygon_kind', 'rectangle');`