### PR TITLE
Configure proxy to use to retrieve tiles.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
     curves instead of straight lines. This functionality can be activated by
     setting the olcs.polygon_kind property to 'rectangle' on the OpenLayers
     geometry.
+  * Add support to set a proxy for Cesium to load layer not accessible 
+    due to missing CORS headers (eg. when user can't modify configuration 
+    of the mapservice used). This functionality can be activated by 
+    setting the olcs.proxy property to the OpenLayers source.
 
 ## v 1.15 - 2016-04-28
 

--- a/src/core/olimageryprovider.js
+++ b/src/core/olimageryprovider.js
@@ -40,6 +40,17 @@ olcs.core.OLImageryProvider = function(source, opt_fallbackProj) {
 
   this.ready_ = false;
 
+  var proxy = this.source_.get('olcs.proxy');
+  if (goog.isDef(proxy)) {
+    if (goog.isFunction(proxy)) {
+      this.proxy_ = {
+        'getURL': proxy
+      };
+    } else if (typeof proxy === 'string') {
+      this.proxy_ = new Cesium.DefaultProxy(proxy);
+    }
+  }
+
   this.errorEvent_ = new Cesium.Event();
 
   this.emptyCanvas_ = document.createElement('canvas');
@@ -120,7 +131,8 @@ Object.defineProperties(olcs.core.OLImageryProvider.prototype, {
   },
 
   proxy: {
-    get: function() {return undefined;}
+    get: /** @this {olcs.core.OLImageryProvider} */
+        function() {return this.proxy_;}
   },
 
   hasAlphaChannel: {
@@ -223,6 +235,9 @@ olcs.core.OLImageryProvider.prototype.requestImage = function(x, y, level) {
 
     var url = tileUrlFunction.call(this.source_,
         [z_, x, y_], 1, this.projection_);
+    if (goog.isDef(this.proxy_)) {
+      url = this.proxy_.getURL(url);
+    }
     return goog.isDef(url) ?
            Cesium.ImageryProvider.loadImage(this, url) : this.emptyCanvas_;
   } else {


### PR DESCRIPTION
Add support to set a proxy for Cesium to load layer not accessible due to missing CORS headers (eg. when user can't modify configuration of the mapservice used). This functionality can be activated by setting the olcs.proxy property to the OpenLayers source.

The following error occurs if CORS is not configured on the remote service:
```
Image from origin 'http://remote.service.org' has been blocked from loading 
by Cross-Origin Resource Sharing policy: 
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

The ```olcs.proxy``` property can contains:
* a function
```
source.set('olcs.proxy', function (url) {
    return '/myproxy?url=' + encodeURIComponent(url);
});
```
* a string pointing to the proxy. In that case a ```Cesium.DefaultProxy``` will be configured on this URL (see https://cesiumjs.org/Cesium/Build/Documentation/DefaultProxy.html).
```
source.set('olcs.proxy', '/myproxy/url');
```


Related discussions:
* http://stackoverflow.com/questions/30738371/proxy-for-wms-layers
