### PR TITLE
Support arbitrary line widths on windows

### DIFF
--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -70,13 +70,13 @@ var styles = {
     stroke: new ol.style.Stroke({
       color: 'green',
       lineDash: [4],
-      width: 1
+      width: 10
     })
   })],
   'MultiLineString': [new ol.style.Style({
     stroke: new ol.style.Stroke({
       color: 'green',
-      width: 1
+      width: 10
     })
   })],
   'MultiPoint': [new ol.style.Style({

--- a/src/featureconverter.js
+++ b/src/featureconverter.js
@@ -172,14 +172,14 @@ olcs.FeatureConverter.prototype.extractColorFromOlStyle = function(style, outlin
 
 /**
  * Return the width of stroke from a plain ol style.
- * Use GL aliased line width range constraint.
  * @param {!ol.style.Style|ol.style.Text} style
  * @return {number}
  * @protected
  */
 olcs.FeatureConverter.prototype.extractLineWidthFromOlStyle = function(style) {
-  var width = style.getStroke() ? style.getStroke().getWidth() : 1;
-  return Math.min(width, this.scene.maximumAliasedLineWidth);
+  // Handling of line width WebGL limitations is handled by Cesium.
+  var width = style.getStroke() ? style.getStroke().getWidth() : undefined;
+  return width !== undefined ? width : 1;
 };
 
 


### PR DESCRIPTION
All browsers on Windows only support a maximum WebGL width of 1.
This commit adds support for arbitrary width.