### PR TITLE
Use export tag instead of goog.exportProperty

### DIFF
--- a/build/jsdoc/api/readme.md
+++ b/build/jsdoc/api/readme.md
@@ -22,4 +22,4 @@ The first two lines are text for the user documentation. This can be long, and i
 
 The second line tells the Closure compiler the type of the argument.
 
-The third line (`@api`) marks the method as part of the api and thus exportable. The stability can be added as value, e.g. `@api stable`. Without such an api annotation, the method will not be documented in the generated API documentation. Symbols without an api annotation will also not be exportable (unless they are explicitly exported with a `goog.exportProperty` call).
+The third line (`@api`) marks the method as part of the api and thus exportable. The stability can be added as value, e.g. `@api stable`. Without such an api annotation, the method will not be documented in the generated API documentation. Symbols without an api annotation will also not be exportable (unless they are explicitly exported with a `@export` jsdoc tag).

--- a/src/core/olimageryprovider.js
+++ b/src/core/olimageryprovider.js
@@ -210,16 +210,16 @@ olcs.core.OLImageryProvider.createCreditForSource = function(source) {
 
 /**
  * TODO: attributions for individual tile ranges
+ * @export
  * @override
  */
 olcs.core.OLImageryProvider.prototype.getTileCredits = function(x, y, level) {
   return undefined;
 };
-goog.exportProperty(olcs.core.OLImageryProvider.prototype, 'getTileCredits',
-                    olcs.core.OLImageryProvider.prototype.getTileCredits);
 
 
 /**
+ * @export
  * @override
  */
 olcs.core.OLImageryProvider.prototype.requestImage = function(x, y, level) {
@@ -245,5 +245,3 @@ olcs.core.OLImageryProvider.prototype.requestImage = function(x, y, level) {
     return this.emptyCanvas_;
   }
 };
-goog.exportProperty(olcs.core.OLImageryProvider.prototype, 'requestImage',
-                    olcs.core.OLImageryProvider.prototype.requestImage);


### PR DESCRIPTION
The build file (`dist/ol3cesium.js`) is the same as before.