### PR TITLE
Allow setting target rendering frame rate

### DIFF
--- a/examples/vectors.html
+++ b/examples/vectors.html
@@ -23,6 +23,11 @@
       onclick="javascript:addOrRemoveOneFeature()" /></div>
     <div><input type="button" value="Toggle clampToGround mode"
       onclick="javascript:toggleClampToGround(); ol3d.getAutoRenderLoop().restartRenderLoop()" /></div>
+    <div>
+      <input id="framerate" type="number" min="0" step="10" value="10"/>
+      <input type="button" value="Set the target rendering frame rate"
+        onclick="javascript:setTargetFrameRate()" />
+    </div>
     <div>Vectors are synchronized from the ol3 map to the Cesium scene.
       <br/>3D positioning and some styling is supported.<br />The render loop is automatically stopped when idle.</div>
     <script src="inject_ol3_cesium.js"></script>

--- a/examples/vectors.js
+++ b/examples/vectors.js
@@ -311,4 +311,13 @@ function toggleClampToGround() {
   map.addLayer(vectorLayer2);
 }
 
+function setTargetFrameRate() {
+  var fps;
+  var fpsEl = document.querySelector('#framerate');
+  if (fpsEl) {
+    fps = Number(fpsEl.value);
+    ol3d.setTargetFrameRate(fps);
+  }
+}
+
 ol3d.enableAutoRenderLoop();

--- a/src/ol3cesium.js
+++ b/src/ol3cesium.js
@@ -334,8 +334,8 @@ olcs.OLCesium.prototype.render_ = function() {
     this.renderId_ = undefined;
   }
 
-  // only render if Cesium is enabled and rendering hasn't been blocked
-  if (this.enabled_ && !this.blockCesiumRendering_) {
+  // only render if Cesium is enabled/warming and rendering hasn't been blocked
+  if ((this.enabled_ || this.warmingUp_) && !this.blockCesiumRendering_) {
     this.renderId_ = requestAnimationFrame(this.onAnimationFrame_.bind(this));
   }
 };
@@ -514,9 +514,6 @@ olcs.OLCesium.prototype.setEnabled = function(enable) {
   }
   this.enabled_ = enable;
 
-  // prevent warm up timeout from disabling rendering
-  this.warmingUp_ = false;
-
   // some Cesium operations are operating with canvas.clientWidth,
   // so we can't remove it from DOM or even make display:none;
   this.container_.style.visibility = this.enabled_ ? 'visible' : 'hidden';
@@ -578,17 +575,11 @@ olcs.OLCesium.prototype.warmUp = function(height, timeout) {
     csCamera.position = ellipsoid.cartographicToCartesian(position);
   }
 
-  // temporarily enable rendering
-  this.enabled_ = true;
   this.warmingUp_ = true;
   this.render_();
 
   setTimeout((function() {
-    // disable rendering after the warm up timeout is reached
-    if (this.warmingUp_) {
-      this.warmingUp_ = false;
-      this.enabled_ = false;
-    }
+    this.warmingUp_ = false;
   }).bind(this), timeout);
 };
 


### PR DESCRIPTION
I added a function to set the target rendering frame rate for Cesium. Our application is using this to reduce the frame rate while parsing large data sets, which speeds up parsing significantly while still providing occasional feedback to the user that data is loading.

@ahocevar or @gberaudo could you review please? Thanks!
