### PR TITLE
Update Cesium private variables in render loop

### DIFF
--- a/src/autorenderloop.js
+++ b/src/autorenderloop.js
@@ -211,8 +211,10 @@ olcs.AutoRenderLoop.prototype.postRender = function(date) {
   var cameraMovedInLastSecond = now - this.lastCameraMoveTime_ < 1000;
 
   var surface = scene.globe['_surface'];
-  var tilesWaiting = !surface['_tileProvider'].ready ||
-      surface['_tileLoadQueue'].length > 0 ||
+  var tilesWaiting = !surface['tileProvider'].ready ||
+      surface['_tileLoadQueueHigh'].length > 0 ||
+      surface['_tileLoadQueueMedium'].length > 0 ||
+      surface['_tileLoadQueueLow'].length > 0 ||
       surface['_debug']['tilesWaitingForChildren'] > 0;
 
   var tweens = scene['tweens'];


### PR DESCRIPTION
Updated the tile checks in `olcs.AutoRenderLoop#postRender` to match those used in `Cesium.Camera#update`. Considered using the `_suspendTerrainAdjustment` private flag in the Cesium camera, but that seemed more fragile to change and less clear to someone trying to understand the olcs code.